### PR TITLE
feat(config): añadir variable de entorno para el nivel de logs

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -9,6 +9,10 @@ ADDON_NAME="AIOStreams"
 # Unique identifier for your addon.
 ADDON_ID="aiostreams.rodezfranco.com"
 
+# --- Logging Configuration ---
+# The level of logging to display. Options: "silent", "error", "warn", "info", "debug", "trace".
+# LOG_LEVEL="info"
+
 # --- Network Configuration ---
 # The port on which the addon will listen.
 # Default: 3000


### PR DESCRIPTION
Se añade la variable de entorno opcional LOG_LEVEL al archivo .env.sample para permitir la configuración de la verbosidad de los logs de la aplicación.