### PR TITLE
fix(ci): usar token personal para la publicación en GHCR

### DIFF
--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
Se modifica el workflow de despliegue para utilizar un Token de Acceso Personal (RELEASE_PLEASE_TOKEN) para la autenticación en GitHub Container Registry.

Esto soluciona un error persistente de 'permission_denied' y asegura que el workflow siempre tenga los permisos necesarios para publicar imágenes.